### PR TITLE
Fix Erlang to point to a URL that doesn't 404.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,6 @@ class erlang($version = '17.0-1')
 
   package { 'Erlang':
     provider => 'pkgdmg',
-    source   => "http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_${version}~osx~${_osx_version}_amd64.dmg"
+    source   => "http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_3_general/esl-erlang_${version}~osx~${_osx_version}_amd64.dmg"
   }
 }


### PR DESCRIPTION
I'm not sure I understand the flavour difference but the previous URL doesn't exist so it's either this or bump to the latest version.

CC @rafaelfranca @dgoodlad for review.