### PR TITLE
Update erlang dmg urls

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,6 @@ class erlang($version = '17.0-1')
 
   package { 'Erlang':
     provider => 'pkgdmg',
-    source   => "http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_3_general/esl-erlang_${version}~osx~${_osx_version}_amd64.dmg"
+    source   => "http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_${version}~osx~${_osx_version}_amd64.dmg"
   }
 }

--- a/spec/classes/erlang_spec.rb
+++ b/spec/classes/erlang_spec.rb
@@ -11,7 +11,7 @@ describe 'erlang' do
     it do
       should contain_package('Erlang').with({
         :provider => 'pkgdmg',
-        :source   => 'http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_3_general/esl-erlang_17.0-1~osx~10.6.8_amd64.dmg'
+        :source   => 'http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_17.0-1~osx~10.6.8_amd64.dmg'
       })
     end
   end
@@ -26,7 +26,7 @@ describe 'erlang' do
     it do
       should contain_package('Erlang').with({
         :provider => 'pkgdmg',
-        :source   => 'http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_3_general/esl-erlang_17.0-1~osx~10.9_amd64.dmg'
+        :source   => 'http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_17.0-1~osx~10.9_amd64.dmg'
       })
     end
   end
@@ -41,7 +41,7 @@ describe 'erlang' do
     it do
       should contain_package('Erlang').with({
         :provider => 'pkgdmg',
-        :source   => 'http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_3_general/esl-erlang_17.0-1~osx~10.9_amd64.dmg'
+        :source   => 'http://packages.erlang-solutions.com/site/esl/esl-erlang/FLAVOUR_1_general/esl-erlang_17.0-1~osx~10.9_amd64.dmg'
       })
     end
   end


### PR DESCRIPTION
The url structure seems to have changed again from FLAVOUR_3_general to FLAVOUR_1_general.
